### PR TITLE
Add option to search by phrase 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 *Maintained by [@SFR-git](https://github.com/SFR-git)*
 # batchful
-A simple and easy-to use directory organizer.
+A simple and easy-to use directory organiser.
 
 No installation needed -- just run `batchful.sh`.
 
 ## Usage
-Run the file from terminal using `$ ./batchful.sh` with the desired organization method and directory.
+Run the file from terminal using `$ ./batchful.sh` with the desired organisation method and directory.
 **OR** Run the file without any parameters / from your file manager.
 
 ### Dependencies
@@ -18,12 +18,13 @@ To run batchful, the following dependencies are needed:
   * from [GitHub](https://github.com/v1cont/yad)
 
 ### Configuration
-There are currently two implemented methods of organization *(more coming soon -- see below)*:
+There are currently two implemented methods of organisation:
 * By file extension: creates a directory for every filetype used in the folder and sorts the files accordingly.
 * By file name: creates a folder for every single file name and sorts the files into them.
+* By phrase: takes files containing a certain phrase in their name and puts them in their own directory.
 
 ### Syntax
-`$ ./batchful.sh [OPTION] [DIRECTORY] [EXTRAOPTION] [EXTRAOPTION] ...`
+`$ ./batchful.sh [OPTION] [DIRECTORY] [CONTEXTUAL] [EXTRAOPTION] [EXTRAOPTION] ...`
 
 #### Options:
 
@@ -35,12 +36,14 @@ There are currently two implemented methods of organization *(more coming soon -
 
 [--help, -h] Prints this help
 
+#### Context-specific options:
+[phrase="foo"] Desired regex to search for
+
 #### Extra options:
 
 [--force, -f] Skip all confirmation prompts.
 
 
 ## Coming Soon
-- The option to sort files by regex: finds a specific phrase anywhere in the file name
 - The ability to search sub-folders for items and rename files if names clash
 - Thinking about an option to toggle case-sensitivity


### PR DESCRIPTION
Added the functionality to use a regex to sort through files: **[--phrase, -p]**

#### Usage
Say you want to take all of the files containing "foo" in their name:
> ```c#
> ./batchful.sh --phrase ~/Documents/Test phrase="foo"
> ```
Note this will also search through extensions -- good for dealing with `.tar.█z` files

This isn't in the GUI just yet; will add soon.